### PR TITLE
New implementation for the BMP280 and BME280

### DIFF
--- a/config/BME280Config.yaml
+++ b/config/BME280Config.yaml
@@ -1,0 +1,7 @@
+# example config for BME280 temperature and pressure sensor
+
+DAQModule: BME280Config
+# I2CADDR: 0x76 # 0x77 is default, 0x76 alternative
+# SeaLevelPressure: 1013.25
+# NChannels: 2 # Description 1 (temperature), 2 (temperature, pressure), 3 (temperature, pressure, altitude),
+#              # 4 (temperature, pressure, altitude, relative_humidity)

--- a/config/BMP180Config.yaml
+++ b/config/BMP180Config.yaml
@@ -1,5 +1,0 @@
-# example config for BMP180 temperature and pressure sensor
-
-DAQModule: BMPx80Config
-# I2CADDR: 0x77 # default, 0x76 alternative
-

--- a/config/BMP280Config.yaml
+++ b/config/BMP280Config.yaml
@@ -1,5 +1,6 @@
-# example config for BMP180 temperature and pressure sensor
+# example config for BMP280 temperature and pressure sensor
 
-DAQModule: BMPx80Config
-I2CADDR: 0x76 # 0x77 is default, 0x76 alternative
-
+DAQModule: BMP280Config
+# I2CADDR: 0x76 # 0x77 is default, 0x76 alternative
+# SeaLevelPressure: 1013.25
+# NChannels: 2 # Description 1 (temperature), 2 (temperature, pressure), 3 (temperature, pressure, altitude)

--- a/config/BMPx80Config.yaml
+++ b/config/BMPx80Config.yaml
@@ -1,0 +1,5 @@
+# example config for the legacy implementation of the BMP180 and BPM280 temperature and pressure sensor
+
+DAQModule: BMPx80Config
+I2CADDR: 0x77 # default for the BMP280 and BMP180, 0x76 alternative
+

--- a/phypidaq/BME280Config.py
+++ b/phypidaq/BME280Config.py
@@ -1,0 +1,53 @@
+import time
+import board
+
+from adafruit_bme280.basic import Adafruit_BME280_I2C
+
+
+class BME280Config(object):
+
+    def __init__(self, config_dict=None):
+
+        if config_dict is None:
+            config_dict = {}
+        if 'I2CADDR' in config_dict:
+            self.I2CADDR = config_dict['I2CADDR']
+        if 'NChannels' in config_dict:
+            self.NChannels = config_dict["NChannels"]
+            if self.NChannels < 1:
+                self.NChannels = 1
+        else:
+            self.NChannels = 2
+        if 'SeaLevelPressure' is config_dict:
+            self.SeaLevelPressure = config_dict['SeaLevelPressure']
+        if self.SeaLevelPressure < 0:
+            self.SeaLevelPressure = 1013.25
+            print("BMP280: sea level pressure set to %.3fA " % self.SeaLevelPressure)
+
+        self.ChanLims = [[-40., 85.], [300., 1100.], [0., 1000.], [0., 100.]]
+        self.ChanNams = ['T', 'P', 'h', 'H']
+        self.ChanUnits = ['°C', 'hPa', 'm', '%']
+
+    def init(self):
+        i2c_bus = board.I2C()
+
+        if hasattr(self, "I2CADDR"):
+            self.sensor = Adafruit_BME280_I2C(i2c_bus, addr=self.I2CADDR)
+        else:
+            self.sensor = Adafruit_BME280_I2C(i2c_bus)
+
+        if hasattr(self, "SeaLevelPressure"):
+            self.sensor.sea_level_pressure = self.SeaLevelPressure
+
+    def acquireData(self, buf):
+        buf[0] = self.sensor.temperature
+        if self.NChannels > 1:
+            buf[1] = self.sensor.pressure
+        if self.NChannels > 2:
+            buf[2] = self.sensor.altitude
+        if self.NChannels > 3:
+            buf[3] = self.sensor.relative_humidity
+
+    def closeDevice(self):
+        # Nothing to do here
+        pass

--- a/phypidaq/BMP280Config.py
+++ b/phypidaq/BMP280Config.py
@@ -1,0 +1,51 @@
+import time
+import board
+
+from adafruit_bmp280 import Adafruit_BMP280_I2C
+
+
+class BMP280Config(object):
+
+    def __init__(self, config_dict=None):
+
+        if config_dict is None:
+            config_dict = {}
+        if 'I2CADDR' in config_dict:
+            self.I2CADDR = config_dict['I2CADDR']
+        if 'NChannels' in config_dict:
+            self.NChannels = config_dict["NChannels"]
+            if self.NChannels < 1:
+                self.NChannels = 1
+        else:
+            self.NChannels = 2
+        if 'SeaLevelPressure' is config_dict:
+            self.SeaLevelPressure = config_dict['SeaLevelPressure']
+        if self.SeaLevelPressure < 0:
+            self.SeaLevelPressure = 1013.25
+            print("BMP280: sea level pressure set to %.3fA " % self.SeaLevelPressure)
+
+        self.ChanLims = [[-40., 85.], [300., 1100.], [0., 1000.]]
+        self.ChanNams = ['T', 'P', 'h']
+        self.ChanUnits = ['°C', 'hPa', 'm']
+
+    def init(self):
+        i2c_bus = board.I2C()
+
+        if hasattr(self, "I2CADDR"):
+            self.sensor = Adafruit_BMP280_I2C(i2c_bus, addr=self.I2CADDR)
+        else:
+            self.sensor = Adafruit_BMP280_I2C(i2c_bus)
+
+        if hasattr(self, "SeaLevelPressure"):
+            self.sensor.sea_level_pressure = self.SeaLevelPressure
+
+    def acquireData(self, buf):
+        buf[0] = self.sensor.temperature
+        if self.NChannels > 1:
+            buf[1] = self.sensor.pressure
+        if self.NChannels > 2:
+            buf[2] = self.sensor.altitude
+
+    def closeDevice(self):
+        # Nothing to do here
+        pass

--- a/phypidaq/__init__.py
+++ b/phypidaq/__init__.py
@@ -26,6 +26,6 @@ __all__ = [ "helpers", "Display", "DataLogger", "DataRecorder", "DataGraphs",
             "ReplayConfig", "ToyDataConfig", 
             "PSConfig", "MCP3x08Config", "ADS1115Config", "groveADCConfig", "GPIOCount",
             "HX711Config", "MAX31865Config", "DS18B20Config", "INA219Config", 
-            "MAX31855Config", "BMP180Config", "BMPx80Config", "MMA8451Config", 
+            "MAX31855Config", "BMP280Config", "BMPx80Config", "MMA8451Config",
             "VL53LxConfig", "TCS34725Config", "AS7262Config", "AS7265xConfig",
-            "GDK101Config", "MLX90393Config" ]
+            "GDK101Config", "MLX90393Config", "BME280Config" ]


### PR DESCRIPTION
Changes:
- The legacy implementation is now fully labeled as BMPx80 and supports BMP180, B280
- Legacy configuration was renamed to BMPx80Config.yaml. BMP180Config.yaml was deleted to continuity and BMP280Config.yaml is now the config file for the new implementation
- BMP280 implementation is now based on the Adafruit library
- BME280 implementation is now based on the Adafruit library

Notes:
- The code has not been tested with the sensors yet.
- As the config files were renamed, this could be considered a breaking change